### PR TITLE
Improve logout behaviour

### DIFF
--- a/src/users/views.py
+++ b/src/users/views.py
@@ -2,6 +2,7 @@
 from typing import List, Type
 
 import dj_rest_auth.views
+from django.contrib.auth import logout
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.debug import sensitive_post_parameters
@@ -45,7 +46,11 @@ class SessionView(ViewSetMixin, dj_rest_auth.views.LoginView):
     def delete(self, request, *args, **kwargs):
         """Logout on delete."""
         self.check_authentication(request)
-        dj_rest_auth.views.LogoutView().logout(request)
+        # only delete the auth token if it was used for authentication
+        if request.auth is not None:
+            request.auth.delete()
+        # issue a django logout - i.e. flush any django sessions
+        logout(request)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     # pylint: disable=unused-argument


### PR DESCRIPTION
@kitdarko Can you please take a look and let me know if you are happy with these changes.

Issuing a delete to the sessions endpoint will now only delete the auth token if request.auth is set. Thus, logging out when authenticating via Django's session authentication backend will not result in the auth token being deleted.